### PR TITLE
Fix cosmetic list truncated #6

### DIFF
--- a/flutter_app/.gitignore
+++ b/flutter_app/.gitignore
@@ -5,9 +5,11 @@
 *.swp
 .DS_Store
 .atom/
+.build/
 .buildlog/
 .history
 .svn/
+.swiftpm/
 migrate_working_dir/
 
 # IntelliJ related

--- a/flutter_app/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/flutter_app/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -59,6 +59,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/flutter_app/lib/pages/app_pages/Search/cosmetics.dart
+++ b/flutter_app/lib/pages/app_pages/Search/cosmetics.dart
@@ -59,6 +59,7 @@ class CosmeticsPageState extends State<CosmeticsPage> {
       body: SafeArea(
         child: SingleChildScrollView(
           child: Column(
+            mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               _buildSearchBar(),
@@ -69,8 +70,8 @@ class CosmeticsPageState extends State<CosmeticsPage> {
                           horizontal: 16.0, vertical: 32.0),
                       child: _buildEmptyState(),
                     )
-                  : SizedBox(
-                      height: MediaQuery.of(context).size.height - 150,
+                  : Flexible(
+                      fit: FlexFit.loose,
                       child: _buildCosmeticList(),
                     ),
             ],
@@ -125,7 +126,9 @@ class CosmeticsPageState extends State<CosmeticsPage> {
 
   Widget _buildCosmeticList() {
     return ListView.builder(
-      padding: EdgeInsets.zero,
+      padding: const EdgeInsets.only(bottom: 40),
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
       itemCount: filteredCosmetics.length,
       itemBuilder: (context, index) {
         final cosmetic = filteredCosmetics[index];


### PR DESCRIPTION
Hi !

Here's the solution I'd like to integrate to fix the truncated list bug in the cosmetics view: 

- used Flexible parent instead of SizedBox
- modified MainAxisSize of the Column parent
- modified some ListView configurations:
  - added padding bottom to prevent the main menu from overtaking the last item
  - modified shrinkWrap to True to ensure it only takes up as much space as needed by its children
  - modified physics to NeverScrollableScrollPhysics to help scroll properly
